### PR TITLE
Fix for compilation error in ppx_cstubs examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,7 +21,7 @@ default: ftw.exe $(EXAMPLES)
 	@dune exec --no-print-directory --display=quiet -- ppx_cstubs $< -pretty -o-ml $(basename $@).ml -o-c $(basename $@)_stubs.c
 
 %.exe: %_stubs.c %.ml
-	@dune exec --no-print-directory --display=quiet -- ocamlfind opt -package ctypes,ctypes.foreign,ppx_cstubs -linkpkg $^ -o $@
+	@dune exec --no-print-directory --display=quiet -- ocamlfind opt -thread -package ctypes,ctypes.foreign,ppx_cstubs -linkpkg $^ -o $@
 
 clean:
 	rm -f *.obj *.o *.cm* *.exe *_stubs.c ftw.ml inline.ml time.ml getpwent.ml


### PR DESCRIPTION
When issuing `make` in the ppx_cstubs `examples` subfolder the following problem is encountered:
```
ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
```
This eventually ends up in a compiler error:

```
File "ftw.ml", line 1:
Error: No implementations provided for the following modules:
         Thread referenced from [ETC. ETC.]/_opam/lib/ctypes/ctypes-foreign.cmxa(Foreign)
         Mutex referenced from [ETC. ETC]/_opam/lib/ctypes/ctypes-foreign.cmxa(Foreign)
```
Other examples e.g. inline.exe etc. also complain about missing -thread

This PR fixes the compilation problem by adding `-thread` to `examples/Makefile`

---
Additionally, I receive the following c-compiler warnings while running `make` in the `examples` folder:

```
ftw_stubs.c: In function ‘ppxc_ftw_c_bf_ftw’:
ftw_stubs.c:75:26: warning: passing argument 2 of ‘ftw’ from incompatible pointer type [-Wincompatible-pointer-types]
   75 |   ppxc__7 = ftw(ppxc__1, ppxc__3, ppxc__5);
      |                          ^~~~~~~
      |                          |
      |                          ppxc_ftw_c_bf_typedef {aka int (*)(char *, void *, int)}
In file included from /usr/include/features.h:461,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/limits.h:26,
                 from /usr/lib/gcc/x86_64-linux-gnu/9/include/limits.h:194,
                 from /usr/lib/gcc/x86_64-linux-gnu/9/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-linux-gnu/9/include/limits.h:34,
                 from [ETC. ETC.]/o412/_opam/lib/ctypes/ctypes_primitives.h:11,
                 from [ETC. ETC.]/o412/_opam/lib/ctypes/ctypes_cstubs_internals.h:13,
                 from ftw_stubs.c:2:
/usr/include/ftw.h:140:12: note: expected ‘__ftw_func_t’ {aka ‘int (*)(const char *, const struct stat *, int)’} but argument is of type ‘ppxc_ftw_c_bf_typedef’ {aka ‘int (*)(char *, void *, int)’}
  140 | extern int __REDIRECT (ftw, (const char *__dir, __ftw_func_t __func,
      |            ^~~~~~~~~~
```

Are these warnings harmless?